### PR TITLE
style: add classnames to grid and styles, move alt font to theme

### DIFF
--- a/src/gatsby-theme-hypercore/theme.js
+++ b/src/gatsby-theme-hypercore/theme.js
@@ -14,12 +14,14 @@ let base = {
     },
   },
   typography: {
-    fontFamily: ["source-code-pro, sans-serif", "zeitung, sans-serif"]
-  }
-}
+    fontFamily: ["source-code-pro, sans-serif", "zeitung, sans-serif"],
+  },
+};
+
+export const ALT_FONT = "zeitung, sans-serif";
 
 const Theme = () => {
-  const theme = createTheme(base)
+  const theme = createTheme(base);
 
   const overrides = {
     overrides: {
@@ -47,12 +49,12 @@ const Theme = () => {
         },
         subtitle1: {
           fontSize: "14px",
-  
+
           margin: "10px 0 10px 0",
         },
         subtitle2: {
           fontSize: "12px",
-  
+
           margin: "10px 0 10px 0",
         },
       },
@@ -71,26 +73,26 @@ const Theme = () => {
       },
       MuiInputBase: {
         root: {
-          fontFamily: 'zeitung',
-          fontWeight: '500',
-          fontSize: '1.1em',
+          fontFamily: ALT_FONT,
+          fontWeight: "500",
+          fontSize: "1.1em",
 
           background: "#E8F5FF",
 
           height: "40px",
-          [theme.breakpoints.down('md')]: {
-            fontFamily: 'zeitung',
-            fontWeight: '500',
-            fontSize: '1em',
+          [theme.breakpoints.down("md")]: {
+            fontFamily: ALT_FONT,
+            fontWeight: "500",
+            fontSize: "1em",
 
-            width: '120px'
+            width: "120px",
           },
-          [theme.breakpoints.up('md')]: {
-            width: '200px'
+          [theme.breakpoints.up("md")]: {
+            width: "200px",
           },
-          [theme.breakpoints.up('lg')]: {
-            width: '200px'
-          }
+          [theme.breakpoints.up("lg")]: {
+            width: "200px",
+          },
         },
       },
       MuiOutlinedInput: {
@@ -117,8 +119,8 @@ const Theme = () => {
       },
       MuiList: {
         padding: {
-          paddingTop: 0
-        }
+          paddingTop: 0,
+        },
       },
       HorizontalNavigation: {
         listItem: {
@@ -159,19 +161,19 @@ const Theme = () => {
       },
       HypNavigation: {
         link: {
-          padding: 0
-        }
+          padding: 0,
+        },
       },
       HypFooter: {
         root: {
-          textAlign: 'center',
-          alignContent: 'center'
-        }
-      }
-    }
-  }
-  
-  return deepmerge(theme, overrides)
+          textAlign: "center",
+          alignContent: "center",
+        },
+      },
+    },
+  };
+
+  return deepmerge(theme, overrides);
 };
 
 export default Theme();

--- a/src/gatsby-theme-hypersite/footer/footer.js
+++ b/src/gatsby-theme-hypersite/footer/footer.js
@@ -6,9 +6,16 @@ import {
 } from "@hyperobjekt/material-ui-website";
 import { Box, Grid, Typography, withStyles } from "@material-ui/core";
 import GatsbyLink from "gatsby-link";
+import { ALT_FONT } from "../../gatsby-theme-hypercore/theme";
 
 // add navigation styles to base navigation component
 const FooterNavigation = withStyles((theme) => ({
+  root: {
+    justifyContent: "center",
+    [theme.breakpoints.up("md")]: {
+      justifyContent: "flex-start",
+    },
+  },
   link: {
     color: theme.palette.common.white,
     textTransform: "uppercase",
@@ -26,32 +33,46 @@ const styles = (theme) => ({
     padding: theme.spacing(12, 0),
     "& .MuiTypography-root": {
       color: theme.palette.common.white,
-    }
-  }
+      fontFamily: ALT_FONT,
+    },
+    "& .footer__logoContainer": {},
+    "& .footer__textContainer": {
+      "& .MuiTypography-root": {
+        maxWidth: theme.spacing(40),
+        margin: "auto", // center in container
+        [theme.breakpoints.up("md")]: {
+          textAlign: "left",
+          marginLeft: 0, // left align in container
+          maxWidth: theme.spacing(64),
+        },
+      },
+    },
+    "& .footer__navContainer": {
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    "& .footer__copyrightContainer": {},
+  },
 });
 
 const Footer = ({ copyright, links, social, ...props }) => {
   return (
     <BaseFooter {...props}>
       <Container>
-        <Grid container>
-          <Grid item xs={12} md={3}>
-            <img src={require('../../../static/images/datahub_logo.png').default} alt='logo' />
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={3} className="footer__logoContainer">
+            <img src="/images/datahub_logo.png" alt="logo" />
           </Grid>
-          <Grid item xs={12} md={6} alignItems="center">
-            <Box maxWidth="32em">
-              <Typography variant="body2">
-                <Box fontFamily='zeitung'>
-                Data Hub is Lorem ipsum dolor sit amet, consectetur adipiscing
-                elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-                aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-                aute irure dolor.
-                </Box>
-              </Typography>
-            </Box>
+          <Grid item xs={12} md={6} className="footer__textContainer">
+            <Typography variant="body2">
+              Data Hub is Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+              aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+              dolor.
+            </Typography>
           </Grid>
-          <Grid item xs={12} md={3}>
+          <Grid item xs={12} md={3} className="footer__navContainer">
             <FooterNavigation
               links={links}
               LinkComponent={GatsbyLink}
@@ -59,12 +80,8 @@ const Footer = ({ copyright, links, social, ...props }) => {
             />
           </Grid>
         </Grid>
-        <Box mt={6}>
-          <Typography variant="body2">
-            <Box fontFamily='zeitung'>
-              {copyright}
-            </Box>
-          </Typography>
+        <Box mt={6} className="footer__copyrightContainer">
+          <Typography variant="body2">{copyright}</Typography>
         </Box>
       </Container>
     </BaseFooter>


### PR DESCRIPTION
# Changes

- add some class names to the grid containers (using [BEM style class names](http://getbem.com/introduction/))
- add styles for the new classes, using `theme.breakpoints` as needed.
- move `zeitung` font declaration to variable in `theme.js` (better to use a variable than hardcode the font name everywhere)
  - added a [fallback font](https://css-tricks.com/css-basics-fallback-font-stacks-robust-web-typography/) (sans-serif) to the zeitung font stack so system sans-serif font loads if zeitung is unavailable. 